### PR TITLE
change default protocol of shadowsocksR

### DIFF
--- a/shadowsocksR.sh
+++ b/shadowsocksR.sh
@@ -261,7 +261,7 @@ config_shadowsocks(){
     "password":"${shadowsockspwd}",
     "timeout":120,
     "method":"aes-256-cfb",
-    "protocol":"origin",
+    "protocol":"auth_sha1_v4_compatible",
     "protocol_param":"",
     "obfs":"plain",
     "obfs_param":"",


### PR DESCRIPTION
I open this pull requests for some reasons:
1. I'm sorry to hear that the origin protocol of shadowsocks can be detected by gfw. Using the origin protocol is probably unsafe to people in Shenzhen .
2. people who want to install shadowsocksR in their server must be interested in the special protocol or obfuscation of shadowsocksR . After they install shadowsocksR by using your scripts , they need to edit the json file to change the protocol . Now they can use auth_sha1_v4 simply without edit anything . If they want to use the origin protocol , it's ok . Because the suffix of '_compatible' means being compatible to the origin protocol of shadowsocks.