### PR TITLE
Use ss-manager instead of ss-server to support multi users

### DIFF
--- a/shadowsocks-libev-debian
+++ b/shadowsocks-libev-debian
@@ -7,15 +7,15 @@
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
 # Short-Description: Fast tunnel proxy that helps you bypass firewalls
-# Description:       Start or stop the Shadowsocks-libev server
+# Description:       Start or stop the Shadowsocks-libev server (manager)
 ### END INIT INFO
 
 # Author: Teddysun <i@teddysun.com>
 
-if [ -f /usr/local/bin/ss-server ]; then
-    DAEMON=/usr/local/bin/ss-server
-elif [ -f /usr/bin/ss-server ]; then
-    DAEMON=/usr/bin/ss-server
+if [ -f /usr/local/bin/ss-manager ]; then
+    DAEMON=/usr/local/bin/ss-manager
+elif [ -f /usr/bin/ss-manager ]; then
+    DAEMON=/usr/bin/ss-manager
 fi
 NAME=Shadowsocks-libev
 CONF=/etc/shadowsocks-libev/config.json


### PR DESCRIPTION
The shadowsocks-libev is a fork and is not fully compatible with the original shadowsocks - it does not understand "port_password" field ([example](https://github.com/shadowsocks/shadowsocks/blob/master/tests/server-multi-passwd.json)) in config file, which prevents using it in multiport and mulituser configurations. This problem is described in [shadowsocks issue](https://github.com/shadowsocks/shadowsocks-libev/issues/1925) and [shadowsocks-libev manual](https://github.com/shadowsocks/shadowsocks-libev/blob/master/doc/ss-server.asciidoc#incompatibility)

To fix this problem shadowsocks-libev offers [ss-manager](https://github.com/shadowsocks/shadowsocks-libev/blob/master/doc/ss-manager.asciidoc). It allows to use the "port_password" field.

This pull request replaces the ss-server to ss-manager in the init script. From my point of view this is a logical approach that makes the shadowsocks-libev compatible with the original manual of shadowsocks.