### PR TITLE
Update libsodium_file and libsodium_url

### DIFF
--- a/shadowsocks-all.sh
+++ b/shadowsocks-all.sh
@@ -37,8 +37,8 @@ plain='\033[0m'
 cur_dir=$( pwd )
 software=(Shadowsocks-Python ShadowsocksR Shadowsocks-Go Shadowsocks-libev)
 
-libsodium_file="libsodium-1.0.16"
-libsodium_url="https://github.com/jedisct1/libsodium/releases/download/1.0.16/libsodium-1.0.16.tar.gz"
+libsodium_file="libsodium-stable"
+libsodium_url="https://download.libsodium.org/libsodium/releases/LATEST.tar.gz"
 
 mbedtls_file="mbedtls-2.13.0"
 mbedtls_url="https://tls.mbed.org/download/mbedtls-2.13.0-gpl.tgz"

--- a/shadowsocks-libev-debian.sh
+++ b/shadowsocks-libev-debian.sh
@@ -12,8 +12,8 @@ export PATH
 # Current folder
 cur_dir=`pwd`
 
-libsodium_file="libsodium-1.0.16"
-libsodium_url="https://github.com/jedisct1/libsodium/releases/download/1.0.16/libsodium-1.0.16.tar.gz"
+libsodium_file="libsodium-stable"
+libsodium_url="https://download.libsodium.org/libsodium/releases/LATEST.tar.gz"
 
 mbedtls_file="mbedtls-2.13.0"
 mbedtls_url="https://tls.mbed.org/download/mbedtls-2.13.0-gpl.tgz"

--- a/shadowsocks-libev.sh
+++ b/shadowsocks-libev.sh
@@ -12,8 +12,8 @@ export PATH
 # Current folder
 cur_dir=`pwd`
 
-libsodium_file="libsodium-1.0.16"
-libsodium_url="https://github.com/jedisct1/libsodium/releases/download/1.0.16/libsodium-1.0.16.tar.gz"
+libsodium_file="libsodium-stable"
+libsodium_url="https://download.libsodium.org/libsodium/releases/LATEST.tar.gz"
 
 mbedtls_file="mbedtls-2.13.0"
 mbedtls_url="https://tls.mbed.org/download/mbedtls-2.13.0-gpl.tgz"

--- a/shadowsocks.sh
+++ b/shadowsocks.sh
@@ -19,8 +19,8 @@ echo "# Github: https://github.com/shadowsocks/shadowsocks        #"
 echo "#############################################################"
 echo
 
-libsodium_file="libsodium-1.0.16"
-libsodium_url="https://github.com/jedisct1/libsodium/releases/download/1.0.16/libsodium-1.0.16.tar.gz"
+libsodium_file="libsodium-stable"
+libsodium_url="https://download.libsodium.org/libsodium/releases/LATEST.tar.gz"
 
 # Current folder
 cur_dir=`pwd`

--- a/shadowsocksR.sh
+++ b/shadowsocksR.sh
@@ -19,8 +19,8 @@ echo "# Github: https://github.com/shadowsocksr/shadowsocksr      #"
 echo "#############################################################"
 echo
 
-libsodium_file="libsodium-1.0.16"
-libsodium_url="https://github.com/jedisct1/libsodium/releases/download/1.0.16/libsodium-1.0.16.tar.gz"
+libsodium_file="libsodium-stable"
+libsodium_url="https://download.libsodium.org/libsodium/releases/LATEST.tar.gz"
 shadowsocks_r_file="shadowsocksr-3.2.2"
 shadowsocks_r_url="https://github.com/shadowsocksrr/shadowsocksr/archive/3.2.2.tar.gz"
 


### PR DESCRIPTION
Update libsodium download link in order to get the latest release better.
[Official libsodium link](https://download.libsodium.org/libsodium/releases/LATEST.tar.gz).
