### PR TITLE
Update shadowsocks-all.sh

### DIFF
--- a/shadowsocks-all.sh
+++ b/shadowsocks-all.sh
@@ -37,11 +37,11 @@ plain='\033[0m'
 cur_dir=$( pwd )
 software=(Shadowsocks-Python ShadowsocksR Shadowsocks-Go Shadowsocks-libev)
 
-libsodium_file="libsodium-1.0.17"
-libsodium_url="https://github.com/jedisct1/libsodium/releases/download/1.0.17/libsodium-1.0.17.tar.gz"
+libsodium_file="libsodium-1.0.18"
+libsodium_url="https://github.com/jedisct1/libsodium/releases/download/1.0.18/libsodium-1.0.18.tar.gz"
 
-mbedtls_file="mbedtls-2.16.0"
-mbedtls_url="https://tls.mbed.org/download/mbedtls-2.16.0-gpl.tgz"
+mbedtls_file="mbedtls-2.16.3"
+mbedtls_url="https://tls.mbed.org/download/mbedtls-2.16.3-gpl.tgz"
 
 shadowsocks_python_file="shadowsocks-master"
 shadowsocks_python_url="https://github.com/shadowsocks/shadowsocks/archive/master.zip"


### PR DESCRIPTION
Bump libsodium to 1.0.18.
Bump mbedtls to 2.16.3.

抹掉了一台 VPS，在全新的系统下运行了更新过的脚本，没有发现问题（Ubuntu 18.04 with hwe-kernel）